### PR TITLE
カレンダーのスクロール非表示

### DIFF
--- a/src/carender.css
+++ b/src/carender.css
@@ -137,3 +137,8 @@
   margin-bottom: 10px;
   /* 下に余白を追加 */
 }
+
+.fc-scroller.fc-scroller-liquid-absolute {
+  overflow: hidden !important;
+  /* スクロールバーを非表示 */
+}


### PR DESCRIPTION
スクロールバーで土曜日セルの表示が崩れていたため非表示化

| before | after |
| -- | -- |
| <img width="1240" alt="スクリーンショット 2024-12-04 21 45 34" src="https://github.com/user-attachments/assets/e3f09b0f-0159-4139-ac6b-9820ea07029e"> | <img width="792" alt="スクリーンショット 2024-12-04 21 33 19" src="https://github.com/user-attachments/assets/f6628a46-6f79-4d1f-9912-c7ee42605926"> |
